### PR TITLE
fix: better time.Time handling among other types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ See @README.md for a project overview.
 - Tell me if something cannot work, and give me alternative approaches
 - Use `any` instead of `interface{}`
 - When generating test files, they should go into their own directory to avoid package name conflicts with the repo root directory
+- Checks against `time.Time` should use `time.Time.IsZero()`
 
 ### Generator Rules
 

--- a/humaclient.go
+++ b/humaclient.go
@@ -170,6 +170,7 @@ func generateClientCode(openapi *huma.OpenAPI, packageName string, opts Options)
 		"lower":      strings.ToLower,
 		"trimPrefix": strings.TrimPrefix,
 		"trimSuffix": strings.TrimSuffix,
+		"hasPrefix":  strings.HasPrefix,
 		"eq": func(a, b any) bool {
 			return a == b
 		},
@@ -1129,6 +1130,12 @@ func (o {{.OptionsStructName}}) Apply(opts *RequestOptions) {
 {{- range .OptionsFields}}
 {{- if eq .Type "string"}}
 	if o.{{.Name}} != "" {
+{{- else if eq .Type "bool"}}
+	if o.{{.Name}} {
+{{- else if eq .Type "time.Time"}}
+	if !o.{{.Name}}.IsZero() {
+{{- else if hasPrefix .Type "*"}}
+	if o.{{.Name}} != nil {
 {{- else}}
 	if o.{{.Name}} != 0 {
 {{- end}}


### PR DESCRIPTION
This PR fixes handling of `time.Time` parameters as well as booleans and pointers.