### PR TITLE
feat: add support for Huma autopatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A library to generate simple clients in Go for interacting with [Huma](https://g
 - Convenient hook to add one-line client generation to your APIs.
 - Maintains Huma docs/validation tags for model re-use in other APIs.
 - Built-in support for paginated responses via `Link` headers with `rel=next`.
+- Support for Huma's autopatch PATCH operations via `Patchable` interface with `MergePatch` and `JSONPatch` types.
+- Conditional request helpers (`WithIfMatch`, `WithIfNoneMatch`) for ETag-based optimistic locking.
 
 These are _not_ supported:
 
@@ -197,6 +199,57 @@ client.ListThings(ctx, exampleapiclient.WithOptions(exampleapiclient.ListThingsO
 	Cursor: "abc123",
 	Limit: 100,
 }))
+```
+
+### Autopatch / JSON Merge Patch
+
+Huma's [autopatch](https://huma.rocks/features/auto-patch/) feature automatically generates PATCH operations from GET + PUT pairs using `application/merge-patch+json`. The client generator detects these operations and generates a `Patchable` interface with two implementations:
+
+- `MergePatch` — a `map[string]any` for [RFC 7396 JSON Merge Patch](https://datatracker.ietf.org/doc/html/rfc7396) partial updates
+- `JSONPatch` — a `[]JSONPatchOp` for [RFC 6902 JSON Patch](https://datatracker.ietf.org/doc/html/rfc6902) operations
+
+The correct `Content-Type` header is set automatically based on which type you use.
+
+```go
+// Merge Patch: send only the fields you want to change
+client.PatchThingByID(ctx, "abc123", exampleapiclient.MergePatch{
+	"name": "new name",
+})
+
+// JSON Patch: explicit list of operations
+client.PatchThingByID(ctx, "abc123", exampleapiclient.JSONPatch{
+	{Op: "replace", Path: "/name", Value: "new name"},
+})
+```
+
+For optimistic locking with ETags, use the generated `WithIfMatch` helper:
+
+```go
+// First, GET the resource and capture the ETag
+resp, thing, _ := client.GetThingByID(ctx, "abc123")
+etag := resp.Header.Get("ETag")
+
+// Then PATCH with If-Match for safe concurrent updates
+client.PatchThingByID(ctx, "abc123", exampleapiclient.MergePatch{
+	"name": "updated name",
+}, exampleapiclient.WithIfMatch(etag))
+```
+
+`WithIfNoneMatch` is also available for conditional requests.
+
+The `Patchable` interface is public, so you can define your own typed patch structs for strong typing if desired:
+
+```go
+type ThingPatch struct {
+	Name string `json:"name,omitempty"`
+}
+
+func (p ThingPatch) PatchContentType() string {
+	return "application/merge-patch+json"
+}
+
+// Use your typed struct just like MergePatch or JSONPatch
+client.PatchThingByID(ctx, "abc123", ThingPatch{Name: "new name"})
 ```
 
 ### Pagination

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/danielgtaylor/humaclient
 
-go 1.25.0
+go 1.23.0
 
 require (
 	github.com/danielgtaylor/casing v0.0.0-20210126043903-4e55e6373ac3

--- a/humaclient.go
+++ b/humaclient.go
@@ -53,7 +53,7 @@ type ClientTemplateData struct {
 	Operations          []OperationData
 	RequestOptionFields []OptionField
 	HasRequestBodies    bool
-	HasMergePatch       bool // Whether any operation uses merge-patch content type
+	HasMergePatch       bool // Whether any operation supports both merge-patch+json and json-patch+json (autopatch)
 	HasJSONPatchOp      bool // Whether JSONPatchOp already exists as a schema struct
 }
 
@@ -94,7 +94,7 @@ type OperationData struct {
 	OptionsFields     []OptionField
 	IsPaginated       bool
 	ItemType          string
-	IsMergePatch      bool   // Whether this operation uses application/merge-patch+json
+	IsMergePatch      bool   // Whether this operation has both merge-patch and json-patch media types (autopatch detection)
 	ItemsField        string // Go struct field name for items array in wrapped responses (e.g. "Items")
 	NextField         string // Go struct field path for next-page URL (e.g. "Next" or "Meta.Next")
 	NextFieldNilCheck string // Nil-check expression for nullable intermediate fields in NextField path

--- a/humaclient.go
+++ b/humaclient.go
@@ -34,6 +34,8 @@ type ClientTemplateData struct {
 	Operations          []OperationData
 	RequestOptionFields []OptionField
 	HasRequestBodies    bool
+	HasMergePatch       bool // Whether any operation uses merge-patch content type
+	HasJSONPatchOp      bool // Whether JSONPatchOp already exists as a schema struct
 }
 
 // SchemaData represents an OpenAPI schema for code generation
@@ -73,6 +75,7 @@ type OperationData struct {
 	OptionsFields     []OptionField
 	IsPaginated       bool
 	ItemType          string
+	IsMergePatch      bool // Whether this operation uses application/merge-patch+json
 }
 
 // ParamData represents a parameter
@@ -242,6 +245,22 @@ func buildTemplateData(openapi *huma.OpenAPI, packageName string, outputDir stri
 	// Generate operations
 	if err := buildOperations(&data.Operations, &data.RequestOptionFields, openapi, opts.AllowedPackages, externalImports, currentPkgPath); err != nil {
 		return nil, fmt.Errorf("failed to build operations: %w", err)
+	}
+
+	// Check if any operations use merge-patch (Patchable) body types
+	for _, op := range data.Operations {
+		if op.IsMergePatch {
+			data.HasMergePatch = true
+			break
+		}
+	}
+
+	// Check if JSONPatchOp already exists as a schema struct (e.g. from Huma autopatch)
+	for _, s := range data.Schemas {
+		if s.StructName == "JSONPatchOp" {
+			data.HasJSONPatchOp = true
+			break
+		}
 	}
 
 	// Add standard library imports that were collected as external imports
@@ -681,12 +700,26 @@ func createOperationData(operation *huma.Operation, method, path string, openapi
 
 // handleRequestBody processes request body for operation data
 func handleRequestBody(opData *OperationData, operation *huma.Operation, openapi *huma.OpenAPI, allowedPackages []string, externalImports map[string]bool, currentPkgPath string) {
-	if operation.RequestBody != nil && operation.RequestBody.Content != nil {
-		if jsonContent := operation.RequestBody.Content["application/json"]; jsonContent != nil {
-			opData.HasRequestBody = true
-			opData.RequestBodyType = schemaToGoType(jsonContent.Schema, openapi, allowedPackages, externalImports, currentPkgPath)
-			opData.HasOptionalBody = !operation.RequestBody.Required
-		}
+	if operation.RequestBody == nil || operation.RequestBody.Content == nil {
+		return
+	}
+
+	// Check for standard JSON content type first
+	if jsonContent := operation.RequestBody.Content["application/json"]; jsonContent != nil {
+		opData.HasRequestBody = true
+		opData.RequestBodyType = schemaToGoType(jsonContent.Schema, openapi, allowedPackages, externalImports, currentPkgPath)
+		opData.HasOptionalBody = !operation.RequestBody.Required
+		return
+	}
+
+	// Check for autopatch: requires both merge-patch and JSON patch content types.
+	// This distinguishes Huma autopatch from manually defined PATCH operations
+	// that may use a single content type with a typed schema.
+	if operation.RequestBody.Content["application/merge-patch+json"] != nil &&
+		operation.RequestBody.Content["application/json-patch+json"] != nil {
+		opData.IsMergePatch = true
+		opData.HasRequestBody = true
+		opData.RequestBodyType = "Patchable"
 	}
 }
 
@@ -774,7 +807,12 @@ func addToOptionsIfNotExists(allOptions map[string]OptionField, operationOptions
 // hasRequestBodies checks if any operation in the API has request bodies
 func hasRequestBodies(openapi *huma.OpenAPI) bool {
 	return hasAnyOperation(openapi, func(op *huma.Operation) bool {
-		return op.RequestBody != nil && op.RequestBody.Content != nil && op.RequestBody.Content["application/json"] != nil
+		if op.RequestBody == nil || op.RequestBody.Content == nil {
+			return false
+		}
+		return op.RequestBody.Content["application/json"] != nil ||
+			(op.RequestBody.Content["application/merge-patch+json"] != nil &&
+				op.RequestBody.Content["application/json-patch+json"] != nil)
 	})
 }
 
@@ -1219,7 +1257,44 @@ func WithOptions(applier OptionsApplier) Option {
 		applier.Apply(opts)
 	}
 }
+{{if .HasMergePatch}}
+// Patchable is an interface for types that can be used as PATCH request bodies.
+// It is implemented by MergePatch and JSONPatch.
+type Patchable interface {
+	PatchContentType() string
+}
 
+// MergePatch represents a JSON Merge Patch (RFC 7396) document.
+// Fields set to non-nil values will be updated; fields set to nil will be removed.
+type MergePatch map[string]any
+
+func (m MergePatch) PatchContentType() string { return "application/merge-patch+json" }
+
+{{if not .HasJSONPatchOp}}
+// JSONPatchOp represents a single JSON Patch (RFC 6902) operation.
+type JSONPatchOp struct {
+	Op    string ` + "`json:\"op\" doc:\"Operation name\" enum:\"add,remove,replace,move,copy,test\"`" + `
+	Path  string ` + "`json:\"path\" doc:\"JSON Pointer to the field being operated on\"`" + `
+	From  string ` + "`json:\"from,omitempty\" doc:\"JSON Pointer for the source of a move or copy\"`" + `
+	Value any    ` + "`json:\"value,omitempty\" doc:\"The value to set\"`" + `
+}
+{{end}}
+// JSONPatch represents a JSON Patch (RFC 6902) document.
+type JSONPatch []JSONPatchOp
+
+func (j JSONPatch) PatchContentType() string { return "application/json-patch+json" }
+
+// WithIfMatch sets the If-Match header for conditional requests.
+// Use this with an ETag value from a previous GET to enable optimistic locking.
+func WithIfMatch(etag string) Option {
+	return WithHeader("If-Match", etag)
+}
+
+// WithIfNoneMatch sets the If-None-Match header for conditional requests.
+func WithIfNoneMatch(etag string) Option {
+	return WithHeader("If-None-Match", etag)
+}
+{{end}}
 {{/* Generate operation-specific option structs and apply methods */}}
 {{- range .Operations}}
 {{- if .OptionsStructName}}
@@ -1369,7 +1444,11 @@ func (c *{{$.ClientStructName}}) {{.MethodName}}(ctx context.Context{{range .Pat
 	// Set content type and apply custom headers
 {{- if or .HasRequestBody .HasOptionalBody}}
 	if reqBody != nil {
+{{- if .IsMergePatch}}
+		req.Header.Set("Content-Type", body.PatchContentType())
+{{- else}}
 		req.Header.Set("Content-Type", "application/json")
+{{- end}}
 	}
 {{- end}}
 	reqOpts.applyHeaders(req)

--- a/humaclient.go
+++ b/humaclient.go
@@ -255,9 +255,9 @@ func buildTemplateData(openapi *huma.OpenAPI, packageName string, outputDir stri
 		}
 	}
 
-	// Check if JSONPatchOp already exists as a schema struct (e.g. from Huma autopatch)
+	// Check if JSONPatchOp already exists as a non-external schema struct (e.g. from Huma autopatch)
 	for _, s := range data.Schemas {
-		if s.StructName == "JSONPatchOp" {
+		if s.StructName == "JSONPatchOp" && !s.IsExternal {
 			data.HasJSONPatchOp = true
 			break
 		}

--- a/humaclient.go
+++ b/humaclient.go
@@ -1445,7 +1445,9 @@ func (c *{{$.ClientStructName}}) {{.MethodName}}(ctx context.Context{{range .Pat
 {{- if or .HasRequestBody .HasOptionalBody}}
 	if reqBody != nil {
 {{- if .IsMergePatch}}
-		req.Header.Set("Content-Type", body.PatchContentType())
+		if body != nil {
+			req.Header.Set("Content-Type", body.PatchContentType())
+		}
 {{- else}}
 		req.Header.Set("Content-Type", "application/json")
 {{- end}}


### PR DESCRIPTION
This pull request adds support for Huma's autopatch feature, enabling automatic client generation for PATCH operations using both JSON Merge Patch and JSON Patch standards. It introduces a `Patchable` interface with helper types and methods, and updates the code generation logic to detect and handle these PATCH operations. The documentation is also updated to explain usage and new features.

**Autopatch and PATCH operation support:**

* Added detection of PATCH operations using both `application/merge-patch+json` and `application/json-patch+json`, marking them as `IsMergePatch` and generating a `Patchable` interface with `MergePatch` and `JSONPatch` types. [[1]](diffhunk://#diff-108fee2655612919c67abc93fe93ce8bf0ffa3dda4930430c3c061861d6d746eL684-R722) [[2]](diffhunk://#diff-108fee2655612919c67abc93fe93ce8bf0ffa3dda4930430c3c061861d6d746eR250-R265) [[3]](diffhunk://#diff-108fee2655612919c67abc93fe93ce8bf0ffa3dda4930430c3c061861d6d746eR78) [[4]](diffhunk://#diff-108fee2655612919c67abc93fe93ce8bf0ffa3dda4930430c3c061861d6d746eR37-R38)
* Updated code generation to set the correct `Content-Type` header for PATCH requests based on the patch type used.

**Conditional request helpers:**

* Added `WithIfMatch` and `WithIfNoneMatch` helper functions to enable ETag-based optimistic locking and conditional requests for PATCH operations.
