### PR TITLE
fix: properly check for empty net.IP

### DIFF
--- a/humaclient.go
+++ b/humaclient.go
@@ -1664,6 +1664,8 @@ func (o {{.OptionsStructName}}) Apply(opts *RequestOptions) {
 	if o.{{.Name}} {
 {{- else if eq .Type "time.Time"}}
 	if !o.{{.Name}}.IsZero() {
+{{- else if eq .Type "net.IP"}}
+	if len(o.{{.Name}}) != 0 {
 {{- else if hasPrefix .Type "*"}}
 	if o.{{.Name}} != nil {
 {{- else}}

--- a/humaclient_test.go
+++ b/humaclient_test.go
@@ -1998,7 +1998,9 @@ func TestStringFormatToGoTypeConversion(t *testing.T) {
 	api := humago.New(mux, huma.DefaultConfig("Format Test API", "1.0.0"))
 
 	huma.Get(api, "/events/{id}", func(ctx context.Context, input *struct {
-		ID string `path:"id"`
+		ID       string `path:"id"`
+		RealIPv4 string `format:"ipv4" header:"X-Real-Ipv4"`
+		RealIPv6 string `format:"ipv6" header:"X-Real-Ipv6"`
 	}) (*struct{ Body EventRecord }, error) {
 		return &struct{ Body EventRecord }{
 			Body: EventRecord{
@@ -2031,6 +2033,10 @@ func TestStringFormatToGoTypeConversion(t *testing.T) {
 	}
 
 	clientCode := string(content)
+
+	if err := exec.Command("go", "build", clientFile).Run(); err != nil {
+		t.Fatalf("Failed to build generated client: %v", err)
+	}
 
 	t.Run("TimeFormatsUseTimeType", func(t *testing.T) {
 		// Check that date-time format uses time.Time


### PR DESCRIPTION
When a `format:"ipv4"` or `format:"ipv6"` input parameter was used,
humaclient would auto-generate the following API client which is not
valid Go code:

    func (o GetOptions) Apply(opts *RequestOptions) {
	    if o.XRealIpv4 != 0 {

As `o.XRealIpv4` is of type `net.IP` (a byte slice), it can't be
compared directly to 0.

This change ensures the generated Go code looks as follows (using `len`):

    func (o GetOptions) Apply(opts *RequestOptions) {
	    if len(o.XRealIpv4) != 0 {