### PR TITLE
feat: enforce required query parameters in generated client

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,15 @@ client.PutThingByID(ctx, "abc123", Thing{
 
 Read on for optional request bodies.
 
+### Required Query Parameters
+
+Query parameters marked `required:"true"` in the API definition are generated as mandatory positional arguments on the client method, so missing them is a compile-time error rather than a silent runtime failure. They are not included in the operation's options struct.
+
+```go
+// Required query params come after path params and before any optional body.
+client.ListThings(ctx, "active", 50)
+```
+
 ### Optional Parameters
 
 You can set optional defined parameters as well as custom query params or headers when making outgoing requests.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ client.ListThings(ctx, "active", 50)
 
 Required values take precedence over any `WithQuery(...)` override targeting the same key, so the typed contract on the method signature stays authoritative.
 
+A parameter marked `required:"true"` that also defines a `default` is treated as optional in the generated client: the server fills in the default when the client omits the value, so promoting it to a mandatory positional argument would force callers to repeat a value they can't meaningfully choose.
+
 Required query parameters are not included in the per-operation options struct. If you were previously passing one of these parameters through `WithOptions(FooOptions{...})`, you will need to lift it to a positional argument when regenerating the client.
 
 ### Optional Parameters

--- a/README.md
+++ b/README.md
@@ -177,12 +177,16 @@ Read on for optional request bodies.
 
 ### Required Query Parameters
 
-Query parameters marked `required:"true"` in the API definition are generated as mandatory positional arguments on the client method, so missing them is a compile-time error rather than a silent runtime failure. They are not included in the operation's options struct.
+Query parameters marked `required:"true"` in the API definition are generated as mandatory positional arguments on the client method, so missing them is a compile-time error rather than a silent runtime failure.
 
 ```go
 // Required query params come after path params and before any optional body.
 client.ListThings(ctx, "active", 50)
 ```
+
+Required values take precedence over any `WithQuery(...)` override targeting the same key, so the typed contract on the method signature stays authoritative.
+
+Required query parameters are not included in the per-operation options struct. If you were previously passing one of these parameters through `WithOptions(FooOptions{...})`, you will need to lift it to a positional argument when regenerating the client.
 
 ### Optional Parameters
 

--- a/humaclient.go
+++ b/humaclient.go
@@ -960,7 +960,11 @@ func buildOperationParams(opData *OperationData, operation *huma.Operation, allO
 		case "query":
 			opData.HasQueryParams = true
 			opData.QueryParams = append(opData.QueryParams, paramData)
-			if paramData.Required {
+			// A documented default means the server fills the value in when the
+			// client omits it, so the parameter is effectively optional on the
+			// wire regardless of what the required flag claims.
+			hasDefault := param.Schema != nil && param.Schema.Default != nil
+			if paramData.Required && !hasDefault {
 				opData.RequiredQueryParams = append(opData.RequiredQueryParams, paramData)
 			} else {
 				addToOptionsIfNotExists(allOptions, &opData.OptionsFields, paramData, "query")

--- a/humaclient.go
+++ b/humaclient.go
@@ -77,31 +77,32 @@ type FieldData struct {
 
 // OperationData represents an API operation for code generation
 type OperationData struct {
-	MethodName        string
-	HTTPMethod        string
-	Path              string
-	PathParams        []ParamData
-	HasRequestBody    bool
-	RequestBodyType   string
-	HasOptionalBody   bool
-	HasResponseBody   bool
-	ReturnType        string
-	ZeroValue         string
-	HasQueryParams    bool
-	HasHeaderParams   bool
-	QueryParams       []ParamData
-	HeaderParams      []ParamData
-	OptionsStructName string
-	OptionsFields     []OptionField
-	IsPaginated       bool
-	ItemType          string
-	IsMergePatch      bool               // Whether this operation has both merge-patch and json-patch media types (autopatch detection)
-	ItemsField        string             // Go struct field name for items array in wrapped responses (e.g. "Items")
-	NextField         string             // Go struct field path for next-page URL (e.g. "Next" or "Meta.Next")
-	NextFieldNilCheck string             // Nil-check expression for nullable intermediate fields in NextField path
-	ResponseType      string             // Wrapper struct type name for object-wrapped paginated responses
-	IsSSE             bool               // Whether this operation returns text/event-stream (SSE)
-	SSEEventTypes     []SSEEventTypeData // Event types for SSE operations
+	MethodName          string
+	HTTPMethod          string
+	Path                string
+	PathParams          []ParamData
+	HasRequestBody      bool
+	RequestBodyType     string
+	HasOptionalBody     bool
+	HasResponseBody     bool
+	ReturnType          string
+	ZeroValue           string
+	HasQueryParams      bool
+	HasHeaderParams     bool
+	QueryParams         []ParamData
+	RequiredQueryParams []ParamData
+	HeaderParams        []ParamData
+	OptionsStructName   string
+	OptionsFields       []OptionField
+	IsPaginated         bool
+	ItemType            string
+	IsMergePatch        bool               // Whether this operation has both merge-patch and json-patch media types (autopatch detection)
+	ItemsField          string             // Go struct field name for items array in wrapped responses (e.g. "Items")
+	NextField           string             // Go struct field path for next-page URL (e.g. "Next" or "Meta.Next")
+	NextFieldNilCheck   string             // Nil-check expression for nullable intermediate fields in NextField path
+	ResponseType        string             // Wrapper struct type name for object-wrapped paginated responses
+	IsSSE               bool               // Whether this operation returns text/event-stream (SSE)
+	SSEEventTypes       []SSEEventTypeData // Event types for SSE operations
 }
 
 // SSEEventTypeData represents a single event type in an SSE operation
@@ -959,7 +960,11 @@ func buildOperationParams(opData *OperationData, operation *huma.Operation, allO
 		case "query":
 			opData.HasQueryParams = true
 			opData.QueryParams = append(opData.QueryParams, paramData)
-			addToOptionsIfNotExists(allOptions, &opData.OptionsFields, paramData, "query")
+			if paramData.Required {
+				opData.RequiredQueryParams = append(opData.RequiredQueryParams, paramData)
+			} else {
+				addToOptionsIfNotExists(allOptions, &opData.OptionsFields, paramData, "query")
+			}
 
 		case "header":
 			opData.HasHeaderParams = true
@@ -1796,12 +1801,12 @@ func parseSSEStream(r io.Reader, unmarshal func(string, []byte) (any, error)) it
 // {{.ClientInterfaceName}} defines the interface for the API client
 type {{.ClientInterfaceName}} interface {
 {{- range .Operations}}
-	{{.MethodName}}(ctx context.Context{{range .PathParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}{{if .HasRequestBody}}, body {{.RequestBodyType}}{{end}}, opts ...Option) {{.ReturnType}}
+	{{.MethodName}}(ctx context.Context{{range .PathParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}{{range .RequiredQueryParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}{{if .HasRequestBody}}, body {{.RequestBodyType}}{{end}}, opts ...Option) {{.ReturnType}}
 {{- if .IsPaginated}}
-	{{.MethodName}}Paginator(ctx context.Context{{range .PathParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}, opts ...Option) iter.Seq2[{{.ItemType}}, error]
+	{{.MethodName}}Paginator(ctx context.Context{{range .PathParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}{{range .RequiredQueryParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}, opts ...Option) iter.Seq2[{{.ItemType}}, error]
 {{- end}}
 {{- if .IsSSE}}
-	{{.MethodName}}Stream(ctx context.Context{{range .PathParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}, opts ...Option) iter.Seq2[SSEEvent, error]
+	{{.MethodName}}Stream(ctx context.Context{{range .PathParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}{{range .RequiredQueryParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}, opts ...Option) iter.Seq2[SSEEvent, error]
 {{- end}}
 {{- end}}
 	Follow(ctx context.Context, link string, result any, opts ...Option) (*http.Response, error)
@@ -1832,7 +1837,7 @@ func NewWithClient(baseURL string, client *http.Client) {{.ClientInterfaceName}}
 {{/* Generate method implementations */}}
 {{- range .Operations}}
 // {{.MethodName}} calls the {{.HTTPMethod}} {{.Path}} endpoint
-func (c *{{$.ClientStructName}}) {{.MethodName}}(ctx context.Context{{range .PathParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}{{if .HasRequestBody}}, body {{.RequestBodyType}}{{end}}, opts ...Option) {{.ReturnType}} {
+func (c *{{$.ClientStructName}}) {{.MethodName}}(ctx context.Context{{range .PathParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}{{range .RequiredQueryParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}{{if .HasRequestBody}}, body {{.RequestBodyType}}{{end}}, opts ...Option) {{.ReturnType}} {
 	// Apply options
 	reqOpts := &RequestOptions{}
 	for _, opt := range opts {
@@ -1853,6 +1858,19 @@ func (c *{{$.ClientStructName}}) {{.MethodName}}(ctx context.Context{{range .Pat
 		return nil, fmt.Errorf("invalid URL: %w", err)
 {{- end}}
 	}
+
+{{- if .RequiredQueryParams}}
+	// Apply required query parameters
+	requiredQueryValues := u.Query()
+{{- range .RequiredQueryParams}}
+{{- if eq .Type "string"}}
+	requiredQueryValues.Set("{{.Name}}", {{.GoNameLowerCamel}})
+{{- else}}
+	requiredQueryValues.Set("{{.Name}}", fmt.Sprintf("%v", {{.GoNameLowerCamel}}))
+{{- end}}
+{{- end}}
+	u.RawQuery = requiredQueryValues.Encode()
+{{- end}}
 
 	// Apply query parameters
 	reqOpts.applyQueryParams(u)
@@ -2019,13 +2037,13 @@ func (c *{{.ClientStructName}}) Follow(ctx context.Context, link string, result 
 {{- range .Operations}}
 {{- if .IsPaginated}}
 // {{.MethodName}}Paginator returns an iterator that fetches all pages of {{.MethodName}} results
-func (c *{{$.ClientStructName}}) {{.MethodName}}Paginator(ctx context.Context{{range .PathParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}, opts ...Option) iter.Seq2[{{.ItemType}}, error] {
+func (c *{{$.ClientStructName}}) {{.MethodName}}Paginator(ctx context.Context{{range .PathParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}{{range .RequiredQueryParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}, opts ...Option) iter.Seq2[{{.ItemType}}, error] {
 	return func(yield func({{.ItemType}}, error) bool) {
 		// Start with the first page
 {{- if .ResponseType}}
-		resp, result, err := c.{{.MethodName}}(ctx{{range .PathParams}}, {{.GoNameLowerCamel}}{{end}}, opts...)
+		resp, result, err := c.{{.MethodName}}(ctx{{range .PathParams}}, {{.GoNameLowerCamel}}{{end}}{{range .RequiredQueryParams}}, {{.GoNameLowerCamel}}{{end}}, opts...)
 {{- else}}
-		resp, items, err := c.{{.MethodName}}(ctx{{range .PathParams}}, {{.GoNameLowerCamel}}{{end}}, opts...)
+		resp, items, err := c.{{.MethodName}}(ctx{{range .PathParams}}, {{.GoNameLowerCamel}}{{end}}{{range .RequiredQueryParams}}, {{.GoNameLowerCamel}}{{end}}, opts...)
 {{- end}}
 		if err != nil {
 			var zero {{.ItemType}}
@@ -2123,9 +2141,9 @@ func unmarshal{{.MethodName}}Data(eventType string, raw []byte) (any, error) {
 }
 
 // {{.MethodName}}Stream returns an iterator that yields parsed SSE events from {{.MethodName}}
-func (c *{{$.ClientStructName}}) {{.MethodName}}Stream(ctx context.Context{{range .PathParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}, opts ...Option) iter.Seq2[SSEEvent, error] {
+func (c *{{$.ClientStructName}}) {{.MethodName}}Stream(ctx context.Context{{range .PathParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}{{range .RequiredQueryParams}}, {{.GoNameLowerCamel}} {{.Type}}{{end}}, opts ...Option) iter.Seq2[SSEEvent, error] {
 	return func(yield func(SSEEvent, error) bool) {
-		resp, err := c.{{.MethodName}}(ctx{{range .PathParams}}, {{.GoNameLowerCamel}}{{end}}, opts...)
+		resp, err := c.{{.MethodName}}(ctx{{range .PathParams}}, {{.GoNameLowerCamel}}{{end}}{{range .RequiredQueryParams}}, {{.GoNameLowerCamel}}{{end}}, opts...)
 		if err != nil {
 			yield(SSEEvent{}, err)
 			return

--- a/humaclient.go
+++ b/humaclient.go
@@ -1859,8 +1859,7 @@ func (c *{{$.ClientStructName}}) {{.MethodName}}(ctx context.Context{{range .Pat
 {{- end}}
 	}
 
-	// Apply custom query parameters first so that required query parameters
-	// below take precedence over any caller-supplied overrides.
+	// Apply query parameters
 	reqOpts.applyQueryParams(u)
 {{- if .RequiredQueryParams}}
 

--- a/humaclient.go
+++ b/humaclient.go
@@ -1859,7 +1859,11 @@ func (c *{{$.ClientStructName}}) {{.MethodName}}(ctx context.Context{{range .Pat
 {{- end}}
 	}
 
+	// Apply custom query parameters first so that required query parameters
+	// below take precedence over any caller-supplied overrides.
+	reqOpts.applyQueryParams(u)
 {{- if .RequiredQueryParams}}
+
 	// Apply required query parameters
 	requiredQueryValues := u.Query()
 {{- range .RequiredQueryParams}}
@@ -1871,9 +1875,6 @@ func (c *{{$.ClientStructName}}) {{.MethodName}}(ctx context.Context{{range .Pat
 {{- end}}
 	u.RawQuery = requiredQueryValues.Encode()
 {{- end}}
-
-	// Apply query parameters
-	reqOpts.applyQueryParams(u)
 
 	// Prepare request body
 	var reqBody io.Reader

--- a/humaclient_test.go
+++ b/humaclient_test.go
@@ -5041,3 +5041,202 @@ func TestNonSSEClientUnchanged(t *testing.T) {
 		t.Error("Non-SSE client should not import strconv")
 	}
 }
+
+func TestRequiredQueryParams(t *testing.T) {
+	// API with a mix of required and optional query parameters.
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Required Query API", "1.0.0"))
+
+	huma.Get(api, "/search", func(ctx context.Context, input *struct {
+		Query  string `query:"q" required:"true" doc:"Search query"`
+		Limit  int    `query:"limit" required:"true" doc:"Page size"`
+		Cursor string `query:"cursor" doc:"Pagination cursor"`
+	}) (*struct{ Body []string }, error) {
+		return &struct{ Body []string }{Body: []string{"a", "b"}}, nil
+	})
+
+	huma.Get(api, "/items/{id}", func(ctx context.Context, input *struct {
+		ID     string `path:"id"`
+		Format string `query:"format" required:"true" doc:"Response format"`
+	}) (*struct{ Body string }, error) {
+		return &struct{ Body string }{Body: input.ID}, nil
+	})
+
+	tempDir, err := os.MkdirTemp("", "humaclient_required_query_*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if err := GenerateClient(api); err != nil {
+		t.Fatalf("Failed to generate client: %v", err)
+	}
+
+	clientFile := "requiredqueryapiclient/client.go"
+	content, err := os.ReadFile(clientFile)
+	if err != nil {
+		t.Fatalf("Failed to read generated client: %v", err)
+	}
+	clientCode := string(content)
+
+	t.Run("RequiredParamsInSignature", func(t *testing.T) {
+		// /search returns a list, so Huma names the op "list-search".
+		if !strings.Contains(clientCode, "ListSearch(ctx context.Context, q string, limit int64, opts ...Option)") {
+			t.Errorf("Expected ListSearch signature with required q and limit args, got:\n%s", clientCode)
+		}
+		// /items/{id} keeps the path param first, then the required query param.
+		if !strings.Contains(clientCode, "GetItemsByID(ctx context.Context, id string, format string, opts ...Option)") {
+			t.Errorf("Expected GetItemsByID signature with id path and format query args, got:\n%s", clientCode)
+		}
+	})
+
+	t.Run("RequiredParamsExcludedFromOptions", func(t *testing.T) {
+		// The options struct for /search should only carry the optional cursor.
+		idx := strings.Index(clientCode, "type ListSearchOptions struct")
+		if idx < 0 {
+			t.Fatalf("Expected ListSearchOptions struct to exist for optional cursor:\n%s", clientCode)
+		}
+		end := strings.Index(clientCode[idx:], "}")
+		if end <= 0 {
+			t.Fatalf("Malformed ListSearchOptions struct in generated code")
+		}
+		optsBlock := clientCode[idx : idx+end]
+		if !strings.Contains(optsBlock, "Cursor string") {
+			t.Errorf("Expected Cursor field in ListSearchOptions, got:\n%s", optsBlock)
+		}
+		if strings.Contains(optsBlock, "Q ") || strings.Contains(optsBlock, "Limit ") {
+			t.Errorf("Required params should not appear in ListSearchOptions, got:\n%s", optsBlock)
+		}
+		// /items/{id} only has one required query param and no optional ones, so
+		// no options struct should be generated for it.
+		if strings.Contains(clientCode, "type GetItemsByIDOptions struct") {
+			t.Errorf("Did not expect GetItemsByIDOptions struct when only required params exist")
+		}
+	})
+
+	t.Run("RequiredParamsAppliedToURL", func(t *testing.T) {
+		if !strings.Contains(clientCode, `requiredQueryValues.Set("q", q)`) {
+			t.Errorf("Expected string required param to be set directly on URL query")
+		}
+		if !strings.Contains(clientCode, `requiredQueryValues.Set("limit", fmt.Sprintf("%v", limit))`) {
+			t.Errorf("Expected non-string required param to be formatted with fmt.Sprintf")
+		}
+		if !strings.Contains(clientCode, `requiredQueryValues.Set("format", format)`) {
+			t.Errorf("Expected format required param to be set on URL query")
+		}
+	})
+
+	t.Run("GeneratedCodeCompiles", func(t *testing.T) {
+		fset := token.NewFileSet()
+		if _, err := parser.ParseFile(fset, clientFile, content, parser.ParseComments); err != nil {
+			t.Fatalf("Generated client has syntax errors: %v", err)
+		}
+	})
+}
+
+func TestRequiredQueryParamsBehavior(t *testing.T) {
+	// Generate a client with required query params and exercise it against a
+	// real test server to verify required values land on the wire.
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Required Query Behavior API", "1.0.0"))
+
+	huma.Get(api, "/search", func(ctx context.Context, input *struct {
+		Query  string `query:"q" required:"true"`
+		Limit  int    `query:"limit" required:"true"`
+		Cursor string `query:"cursor"`
+	}) (*struct{ Body []string }, error) {
+		return &struct{ Body []string }{Body: []string{"a"}}, nil
+	})
+
+	tempDir, err := os.MkdirTemp("", "humaclient_required_query_behavior_*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if err := GenerateClient(api); err != nil {
+		t.Fatalf("Failed to generate client: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Echo back the query values that hit the server so the test can
+		// verify them via resp.Request.URL on the client side. The body is a
+		// JSON array to match the generated client's []string return type.
+		json.NewEncoder(w).Encode([]string{
+			"q=" + r.URL.Query().Get("q"),
+			"limit=" + r.URL.Query().Get("limit"),
+			"cursor=" + r.URL.Query().Get("cursor"),
+		})
+	}))
+	defer server.Close()
+
+	if err := os.WriteFile("go.mod", []byte("module testprogram\ngo 1.23\n"), 0644); err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	prog := fmt.Sprintf(`
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+	"testprogram/requiredquerybehaviorapiclient"
+)
+
+func main() {
+	client := requiredquerybehaviorapiclient.NewWithClient("%s", &http.Client{Timeout: 5 * time.Second})
+
+	resp, _, err := client.ListSearch(context.Background(), "hello world", 25,
+		requiredquerybehaviorapiclient.WithOptions(requiredquerybehaviorapiclient.ListSearchOptions{
+			Cursor: "abc",
+		}))
+	if err != nil {
+		fmt.Printf("ERROR: %%v\n", err)
+		os.Exit(1)
+	}
+
+	json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"url":    resp.Request.URL.String(),
+		"status": resp.StatusCode,
+	})
+}
+`, server.URL)
+
+	if err := os.WriteFile("main.go", []byte(prog), 0644); err != nil {
+		t.Fatalf("Failed to write test program: %v", err)
+	}
+
+	output, err := runGoProgram("main.go")
+	if err != nil {
+		t.Fatalf("Test program failed: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v\nRaw: %s", err, output)
+	}
+
+	requestURL := result["url"].(string)
+	if !strings.Contains(requestURL, "q=hello+world") && !strings.Contains(requestURL, "q=hello%20world") {
+		t.Errorf("Expected URL to contain encoded q param, got: %s", requestURL)
+	}
+	if !strings.Contains(requestURL, "limit=25") {
+		t.Errorf("Expected URL to contain limit=25, got: %s", requestURL)
+	}
+	if !strings.Contains(requestURL, "cursor=abc") {
+		t.Errorf("Expected optional cursor=abc to still flow through, got: %s", requestURL)
+	}
+}

--- a/humaclient_test.go
+++ b/humaclient_test.go
@@ -5241,6 +5241,61 @@ func main() {
 	}
 }
 
+func TestRequiredQueryParamsWithDefaultDemoted(t *testing.T) {
+	// A query param marked required:"true" but also carrying a default value is
+	// effectively optional on the wire (the server fills it in), so the
+	// generated client should keep it in the options struct rather than
+	// promoting it to a required positional argument.
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Required With Default API", "1.0.0"))
+
+	huma.Get(api, "/search", func(ctx context.Context, input *struct {
+		Query string `query:"q" required:"true"`
+		Limit int    `query:"limit" required:"true" default:"10"`
+	}) (*struct{ Body []string }, error) {
+		return &struct{ Body []string }{Body: []string{"a"}}, nil
+	})
+
+	tempDir, err := os.MkdirTemp("", "humaclient_required_with_default_*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if err := GenerateClient(api); err != nil {
+		t.Fatalf("Failed to generate client: %v", err)
+	}
+
+	content, err := os.ReadFile("requiredwithdefaultapiclient/client.go")
+	if err != nil {
+		t.Fatalf("Failed to read generated client: %v", err)
+	}
+	clientCode := string(content)
+
+	// q has no default → required positional arg.
+	// limit has a default → demoted to the options struct.
+	if !strings.Contains(clientCode, "ListSearch(ctx context.Context, q string, opts ...Option)") {
+		t.Errorf("Expected ListSearch to keep q as a required arg and demote limit, got:\n%s", clientCode)
+	}
+	if strings.Contains(clientCode, "limit int64, opts") {
+		t.Errorf("Did not expect limit to remain a required positional arg when a default is set")
+	}
+
+	idx := strings.Index(clientCode, "type ListSearchOptions struct")
+	if idx < 0 {
+		t.Fatalf("Expected ListSearchOptions struct for demoted limit field")
+	}
+	end := strings.Index(clientCode[idx:], "}")
+	optsBlock := clientCode[idx : idx+end]
+	if !strings.Contains(optsBlock, "Limit ") {
+		t.Errorf("Expected demoted Limit field in options struct, got:\n%s", optsBlock)
+	}
+}
+
 func TestRequiredQueryParamsOverridePrecedence(t *testing.T) {
 	// Required positional args must win over caller-supplied overrides via
 	// WithQuery, so the typed API contract stays authoritative.

--- a/humaclient_test.go
+++ b/humaclient_test.go
@@ -5240,3 +5240,89 @@ func main() {
 		t.Errorf("Expected optional cursor=abc to still flow through, got: %s", requestURL)
 	}
 }
+
+func TestRequiredQueryParamsOverridePrecedence(t *testing.T) {
+	// Required positional args must win over caller-supplied overrides via
+	// WithQuery, so the typed API contract stays authoritative.
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Required Query Precedence API", "1.0.0"))
+
+	huma.Get(api, "/search", func(ctx context.Context, input *struct {
+		Query string `query:"q" required:"true"`
+	}) (*struct{ Body []string }, error) {
+		return &struct{ Body []string }{Body: []string{"a"}}, nil
+	})
+
+	tempDir, err := os.MkdirTemp("", "humaclient_required_query_precedence_*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if err := GenerateClient(api); err != nil {
+		t.Fatalf("Failed to generate client: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]string{"q=" + r.URL.Query().Get("q")})
+	}))
+	defer server.Close()
+
+	if err := os.WriteFile("go.mod", []byte("module testprogram\ngo 1.23\n"), 0644); err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	prog := fmt.Sprintf(`
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+	"testprogram/requiredqueryprecedenceapiclient"
+)
+
+func main() {
+	client := requiredqueryprecedenceapiclient.NewWithClient("%s", &http.Client{Timeout: 5 * time.Second})
+
+	resp, _, err := client.ListSearch(context.Background(), "authoritative",
+		requiredqueryprecedenceapiclient.WithQuery("q", "override-attempt"))
+	if err != nil {
+		fmt.Printf("ERROR: %%v\n", err)
+		os.Exit(1)
+	}
+
+	json.NewEncoder(os.Stdout).Encode(map[string]any{"url": resp.Request.URL.String()})
+}
+`, server.URL)
+
+	if err := os.WriteFile("main.go", []byte(prog), 0644); err != nil {
+		t.Fatalf("Failed to write test program: %v", err)
+	}
+
+	output, err := runGoProgram("main.go")
+	if err != nil {
+		t.Fatalf("Test program failed: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v\nRaw: %s", err, output)
+	}
+
+	requestURL := result["url"].(string)
+	if !strings.Contains(requestURL, "q=authoritative") {
+		t.Errorf("Expected required positional arg to win over WithQuery override, got: %s", requestURL)
+	}
+	if strings.Contains(requestURL, "q=override-attempt") {
+		t.Errorf("WithQuery should not have overridden the required positional arg, got: %s", requestURL)
+	}
+}


### PR DESCRIPTION
Query parameters marked `required: true` in the OpenAPI spec are now emitted as mandatory positional arguments on the generated client method (and on the matching interface, paginator, and SSE stream signatures), so callers that omit them fail at compile time instead of silently issuing a malformed request.

Optional query parameters continue to flow through the per-operation options struct, so existing clients that already pass their required values via that path keep compiling after regeneration.